### PR TITLE
Fix and update version file

### DIFF
--- a/CollisionFX-ReUpdated/GameData/CollisionFXReUpdated/Versioning/CollisionFX-ReUpdated.version
+++ b/CollisionFX-ReUpdated/GameData/CollisionFXReUpdated/Versioning/CollisionFX-ReUpdated.version
@@ -1,13 +1,11 @@
 {
-    "NAME":"CollisionFX-ReUpdated",
-	"URL":"https://forum.kerbalspaceprogram.com/index.php?/topic/193803-19x-collisionfx-reupdated/",
-    "DOWNLOAD":"", //Coming Soon
-
+    "NAME": "CollisionFX-ReUpdated",
+    "URL": "https://github.com/VoidCosmo/CollisionFX-ReUpdated/raw/master/CollisionFX-ReUpdated/src/CollisionFX/CollisionFX-ReUpdated.version",
+    "DOWNLOAD": "https://spacedock.info/mod/2426/CollisionFX-ReUpdated",
     "VERSION":{
         "MAJOR":1,
-        "MINOR":0,
-        "PATCH":0,
-        "BUILD":0
+        "MINOR":1,
+        "PATCH":0
     },
     "KSP_VERSION":{
         "MAJOR":1,
@@ -16,12 +14,10 @@
     },
     "KSP_VERSION_MIN":{
         "MAJOR":1,
-        "MINOR":8,
-        "PATCH":0
+        "MINOR":8
     },
     "KSP_VERSION_MAX":{
         "MAJOR":1,
-        "MINOR":9,
-        "PATCH":99
+        "MINOR":9
     }
 }

--- a/CollisionFX-ReUpdated/src/CollisionFX/CollisionFX-ReUpdated.version
+++ b/CollisionFX-ReUpdated/src/CollisionFX/CollisionFX-ReUpdated.version
@@ -1,13 +1,11 @@
 {
-    "NAME":"CollisionFX-ReUpdated",
-	"URL":"https://forum.kerbalspaceprogram.com/index.php?/topic/193803-19x-collisionfx-reupdated/",
-    "DOWNLOAD":"", //Coming Soon
-
+    "NAME": "CollisionFX-ReUpdated",
+    "URL": "https://github.com/VoidCosmo/CollisionFX-ReUpdated/raw/master/CollisionFX-ReUpdated/src/CollisionFX/CollisionFX-ReUpdated.version",
+    "DOWNLOAD": "https://spacedock.info/mod/2426/CollisionFX-ReUpdated",
     "VERSION":{
         "MAJOR":1,
-        "MINOR":0,
-        "PATCH":0,
-        "BUILD":0
+        "MINOR":1,
+        "PATCH":0
     },
     "KSP_VERSION":{
         "MAJOR":1,
@@ -16,12 +14,10 @@
     },
     "KSP_VERSION_MIN":{
         "MAJOR":1,
-        "MINOR":8,
-        "PATCH":0
+        "MINOR":8
     },
     "KSP_VERSION_MAX":{
         "MAJOR":1,
-        "MINOR":9,
-        "PATCH":99
+        "MINOR":9
     }
 }

--- a/GameData/CollisionFXReUpdated/Versioning/CollisionFX-ReUpdated.version
+++ b/GameData/CollisionFXReUpdated/Versioning/CollisionFX-ReUpdated.version
@@ -1,13 +1,11 @@
 {
-    "NAME":"CollisionFX-ReUpdated",
-	"URL":"https://forum.kerbalspaceprogram.com/index.php?/topic/193803-19x-collisionfx-reupdated/",
-    "DOWNLOAD":"", //Coming Soon
-
+    "NAME": "CollisionFX-ReUpdated",
+    "URL": "https://github.com/VoidCosmo/CollisionFX-ReUpdated/raw/master/CollisionFX-ReUpdated/src/CollisionFX/CollisionFX-ReUpdated.version",
+    "DOWNLOAD": "https://spacedock.info/mod/2426/CollisionFX-ReUpdated",
     "VERSION":{
         "MAJOR":1,
-        "MINOR":0,
-        "PATCH":0,
-        "BUILD":0
+        "MINOR":1,
+        "PATCH":0
     },
     "KSP_VERSION":{
         "MAJOR":1,
@@ -16,12 +14,10 @@
     },
     "KSP_VERSION_MIN":{
         "MAJOR":1,
-        "MINOR":8,
-        "PATCH":0
+        "MINOR":8
     },
     "KSP_VERSION_MAX":{
         "MAJOR":1,
-        "MINOR":9,
-        "PATCH":99
+        "MINOR":9
     }
 }

--- a/src/CollisionFX/CollisionFX-ReUpdated.version
+++ b/src/CollisionFX/CollisionFX-ReUpdated.version
@@ -1,13 +1,11 @@
 {
-    "NAME":"CollisionFX-ReUpdated",
-	"URL":"https://forum.kerbalspaceprogram.com/index.php?/topic/193803-19x-collisionfx-reupdated/",
-    "DOWNLOAD":"", //Coming Soon
-
+    "NAME": "CollisionFX-ReUpdated",
+    "URL": "https://github.com/VoidCosmo/CollisionFX-ReUpdated/raw/master/CollisionFX-ReUpdated/src/CollisionFX/CollisionFX-ReUpdated.version",
+    "DOWNLOAD": "https://spacedock.info/mod/2426/CollisionFX-ReUpdated",
     "VERSION":{
         "MAJOR":1,
-        "MINOR":0,
-        "PATCH":0,
-        "BUILD":0
+        "MINOR":1,
+        "PATCH":0
     },
     "KSP_VERSION":{
         "MAJOR":1,
@@ -16,12 +14,10 @@
     },
     "KSP_VERSION_MIN":{
         "MAJOR":1,
-        "MINOR":8,
-        "PATCH":0
+        "MINOR":8
     },
     "KSP_VERSION_MAX":{
         "MAJOR":1,
-        "MINOR":9,
-        "PATCH":99
+        "MINOR":9
     }
 }


### PR DESCRIPTION
The current version file is broken and outdated:

* It contains a comment beginning with `//`, however the JSON standard doesn't define comments. This breaks most JSON parsers.
* `DOWNLOAD` now points to SpaceDock.
* The `URL` property points to the forum thread, however that's not how it should be used according to the AVC schema:
    ```
    "URL": {
        "description": "Location of a remote version file for update checking",
        "type": "string",
        "format": "uri"
    },
    ```
    It's now updated to point to one of the many files hosted in this repository. Please make sure to always keep this URL up-to-date, e.g. if you decide to delete or move this file.
* `VERSION` is now saying `1.1.0`.

Since the repository is a bit messy, I wasn't entirely sure which one of the four files to update, so I decided to update all of them.

Pinging @VoidCosmo in case you have PR notifications off.